### PR TITLE
Correção falta de dois pontos no arquivo json ("pragmarx/sqli" "0.*") da...

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,7 +166,7 @@ But you can also escape them with \
 
 Require the Select package:
 
-    composer require "pragmarx/sqli" "0.*"
+    composer require "pragmarx/sqli":"0.*"
 
 Add the service provider to your app/config/app.php:
 


### PR DESCRIPTION
... linha 169 do readme.php

Correção da falta de dois pontos entre as informações do json.
Errado - "pragmarx/sqli" "0._"
Correto - "pragmarx/sqli":"0._"
